### PR TITLE
chore: techrank-problems-spring-boot-reactjs-basic to 0.0.4

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -12,4 +12,4 @@ dependencies:
   version: 0.0.1
 - name: techrank-problems-spring-boot-reactjs-basic
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.3
+  version: 0.0.4


### PR DESCRIPTION
chore: Promote techrank-problems-spring-boot-reactjs-basic to version 0.0.4